### PR TITLE
Specify which params get passed to jax.jacfwd

### DIFF
--- a/luca_gnfw.py
+++ b/luca_gnfw.py
@@ -255,9 +255,11 @@ def val_conv_int_gnfw(
     T_electron=5.0,
     r_map=15.0 * 60,
     dr=0.5,
+    grad_args=[True, True, True, True, True, True, True, True], 
 ):
+    x0, y0, P0, c500, alpha, beta, gamma, m500 = p
     return conv_int_gnfw(
-        p, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
+        x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
 
 
@@ -282,9 +284,12 @@ def jac_conv_int_gnfw_fwd(
     T_electron=5.0,
     r_map=15.0 * 60,
     dr=0.5,
+    grad_args=[True, True, True, True, True, True, True, True], 
 ):
-    return jax.jacfwd(conv_int_gnfw, argnums=0)(
-        p, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
+    x0, y0, P0, c500, alpha, beta, gamma, m500 = p
+    argnums = np.arange(len(p))[grad_args]
+    return jax.jacfwd(conv_int_gnfw, argnums=argnums)(
+        x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
 
 
@@ -309,12 +314,14 @@ def jit_conv_int_gnfw(
     T_electron=5.0,
     r_map=15.0 * 60,
     dr=0.5,
+    grad_args=[True, True, True, True, True, True, True, True], 
 ):
     x0, y0, P0, c500, alpha, beta, gamma, m500 = p
     pred = conv_int_gnfw(
         x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
-    grad = jax.jacfwd(conv_int_gnfw, argnums=0)(
+    argnums = np.arange(len(p))[grad_args]
+    grad = jax.jacfwd(conv_int_gnfw, argnums=argnums)(
         x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
 
@@ -342,9 +349,11 @@ def jit_conv_int_gnfw_elliptical(
     T_electron=5.0,
     r_map=15.0 * 60,
     dr=0.5,
+    grad_args=[True, True, True, True, True, True, True, True, True, True, True], 
 ):
+    x_scale, y_scale, theta, x0, y0, P0, c500, alpha, beta, gamma, m500 = p
     pred = conv_int_gnfw_elliptical(
-        p,
+        x_scale, y_scale, theta, x0, y0, P0, c500, alpha, beta, gamma, m500,
         tods[0],
         tods[1],
         z,
@@ -355,8 +364,9 @@ def jit_conv_int_gnfw_elliptical(
         r_map,
         dr,
     )
-    grad = jax.jacfwd(conv_int_gnfw_elliptical, argnums=0)(
-        p,
+    argnums = np.arange(len(p))[grad_args]
+    grad = jax.jacfwd(conv_int_gnfw_elliptical, argnums=argnums)(
+        x_scale, y_scale, theta, x0, y0, P0, c500, alpha, beta, gamma, m500,
         tods[0],
         tods[1],
         z,

--- a/luca_gnfw.py
+++ b/luca_gnfw.py
@@ -288,9 +288,10 @@ def jac_conv_int_gnfw_fwd(
     grad = jax.jacfwd(conv_int_gnfw, argnums=argnums)(
         x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
+    grad = jnp.array(grad)
 
     if len(argnums) != len(p):
-        padded_grad = jnp.zeros(p.shape + grad[0].shape)
+        padded_grad = jnp.zeros(p.shape + grad[0].shape) + 1e-30
         grad = padded_grad.at[jnp.array(argnums)].set(jnp.array(grad))
 
     return grad
@@ -327,9 +328,10 @@ def jit_conv_int_gnfw(
     grad = jax.jacfwd(conv_int_gnfw, argnums=argnums)(
         x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
+    grad = jnp.array(grad)
 
     if len(argnums) != len(p):
-        padded_grad = jnp.zeros(p.shape + grad[0].shape)
+        padded_grad = jnp.zeros(p.shape + grad[0].shape) + 1e-30
         grad = padded_grad.at[jnp.array(argnums)].set(jnp.array(grad))
 
     return pred, grad
@@ -384,9 +386,10 @@ def jit_conv_int_gnfw_elliptical(
         r_map,
         dr,
     )
+    grad = jnp.array(grad)
 
     if len(argnums) != len(p):
-        padded_grad = jnp.zeros(p.shape + grad[0].shape)
+        padded_grad = jnp.zeros(p.shape + grad[0].shape) + 1e-30
         grad = padded_grad.at[jnp.array(argnums)].set(jnp.array(grad))
 
     return pred, grad

--- a/luca_gnfw.py
+++ b/luca_gnfw.py
@@ -77,9 +77,9 @@ def y2K_RJ(freq, Te):
 
 # Beam-convolved gNFW profiel
 # --------------------------------------------------------
-@jax.partial(jax.jit, static_argnums=(4, 5, 6, 7, 8, 9))
+@jax.partial(jax.jit, static_argnums=(11, 12, 13, 14, 15, 16))
 def _conv_int_gnfw(
-    p,
+    x0, y0, P0, c500, alpha, beta, gamma, m500,
     xi,
     yi,
     z,
@@ -90,8 +90,6 @@ def _conv_int_gnfw(
     r_map=15.0 * 60,
     dr=0.5,
 ):
-    x0, y0, P0, c500, alpha, beta, gamma, m500 = p
-
     hz = jnp.interp(z, dzline, hzline)
     nz = jnp.interp(z, dzline, nzline)
 
@@ -143,7 +141,7 @@ def _conv_int_gnfw(
 
 
 def conv_int_gnfw(
-    p,
+    x0, y0, P0, c500, alpha, beta, gamma, m500,
     xi,
     yi,
     z,
@@ -154,10 +152,8 @@ def conv_int_gnfw(
     r_map=15.0 * 60,
     dr=0.5,
 ):
-    x0, y0, P0, c500, alpha, beta, gamma, m500 = p
-
     rmap, ip = _conv_int_gnfw(
-        p,
+        x0, y0, P0, c500, alpha, beta, gamma, m500,
         xi,
         yi,
         z,
@@ -177,7 +173,7 @@ def conv_int_gnfw(
 
 
 def conv_int_gnfw_elliptical(
-    p,
+    x_scale, y_scale, theta, x0, y0, P0, c500, alpha, beta, gamma, m500,
     xi,
     yi,
     z,
@@ -208,7 +204,7 @@ def conv_int_gnfw_elliptical(
     x_scale, y_scale, theta, x0, y0, P0, c500, alpha, beta, gamma, m500 = p
 
     rmap, ip = _conv_int_gnfw(
-        p[3:],
+        x0, y0, P0, c500, alpha, beta, gamma, m500,
         xi,
         yi,
         z,
@@ -314,11 +310,12 @@ def jit_conv_int_gnfw(
     r_map=15.0 * 60,
     dr=0.5,
 ):
+    x0, y0, P0, c500, alpha, beta, gamma, m500 = p
     pred = conv_int_gnfw(
-        p, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
+        x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
     grad = jax.jacfwd(conv_int_gnfw, argnums=0)(
-        p, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
+        x0, y0, P0, c500, alpha, beta, gamma, m500, tods[0], tods[1], z, max_R, fwhm, freq, T_electron, r_map, dr
     )
 
     return pred, grad


### PR DESCRIPTION
The time of `jit_conv_int_gnfw` is dominated by the differentiation, time scales roughly linearly with the number of arguments you diff over. 

Note the function now outputs `grad` with the axis in a different order, removing the need for `derivs = jnp.moveaxis(derivs, 2, 0)` in a helper function.

To specify which arguments to use pass a tuple with the argument numbers as `argnums`. This can be done in a helper function like this:

```
def helper(params, tod):
      x = tod.info['dx']
      y = tod.info['dy']

      xy = [x, y]
      xy = jnp.asarray(xy)
       
     argnums = [i for i, p in enumerate(to_fit[:len(params)]) if p]
     pred, derivs = jit_conv_int_gnfw_elliptical(params, xy, z, argnums=tuple(argnums))

    return derivs, pred
```

This function assumes that `to_fit` is declared before the function is called (not currently the case in `ms0735.py` but fixing this just requires moving its declaration up)

